### PR TITLE
Fix citation of Khu98.

### DIFF
--- a/doc/lieprings-theory.tex
+++ b/doc/lieprings-theory.tex
@@ -2,7 +2,7 @@
 \Chapter{Lie p-rings}
 
 In this preliminary chapter we recall some of theoretic background
-of Lie rings and Lie $p$-rings. We refer to Chapter 5 in \cite{Khu} 
+of Lie rings and Lie $p$-rings. We refer to Chapter 5 in \cite{Khu98}
 for some further details. Throughout we assume that $p$ stands for 
 a rational prime.
 \medskip


### PR DESCRIPTION
The label "Khu98" is defined in doc/liepring.bib, but the citation refers simply to "Khu", leading to these complaints from bibtex:
```
Database file #1: liepring.bib
Warning--I didn't find a database entry for "Khu"
(There was 1 warning)
```
and pdftex:
```
 )pdfTeX warning (dest): name{citation@Khu} has been referenced but does not exist, replaced by a fixed one
```