### PR TITLE
add a nontrivial `AvailabilityTest` function

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -54,7 +54,31 @@ PackageDoc := rec(
   LongTitle := "LiePRing Package",
 ),
 
-AvailabilityTest := ReturnTrue,
+AvailabilityTest := function()
+  # When LiePRing gets loaded, the Singular package will be loaded,
+  # and then 'StartSingular()' will be called in read.g,
+  # without modifying the variable 'sing_exec'.
+  # Thus we use the code from Singular's
+  # 'CheckSingularExecutableAndTempDir' in order to determine
+  # whether a Singular executable will be found by the Singular package.
+  # If not then LiePRing cannot be loaded,
+  # because otherwise the call of 'StartSingular()' would run into an error.
+  local IsExec, sing_exec;
+
+  IsExec:= path -> IsString( path ) and not IsDirectoryPath( path )
+                   and IsExecutableFile( path );
+
+  sing_exec:= "singular";
+  if IsDirectoryPath( sing_exec ) then
+    sing_exec:= Filename( Directory( sing_exec ), "Singular" );
+  elif not IsExecutableFile( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), sing_exec );
+  fi;
+  if not IsExec( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), "Singular" );
+  fi;
+  return IsExec( sing_exec );
+end,
 
 Dependencies := rec(
   GAP := "4.8",

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -68,7 +68,12 @@ AvailabilityTest := function()
   IsExec:= path -> IsString( path ) and not IsDirectoryPath( path )
                    and IsExecutableFile( path );
 
-  sing_exec:= "singular";
+  if IsBoundGlobal( "sing_exec" ) then
+    # The Singular package has been loaded.
+    sing_exec:= ValueGlobal( "sing_exec" );
+  else
+    sing_exec:= "singular";
+  fi;
   if IsDirectoryPath( sing_exec ) then
     sing_exec:= Filename( Directory( sing_exec ), "Singular" );
   elif not IsExecutableFile( sing_exec ) then


### PR DESCRIPTION
LiePRing needs the package Singular.
Singular can be loaded, no matter whether a Singular executable is available; the idea is that either the default location of the standalone fits, or that one first loads Singular and then configures the path of the executable before one starts Singular.
(And it is even supported to start Singular interactively, and then set the path of its executable from the GAP break loop.)

Thus we cannot expect a `TestAvailability` function of Singular that returns `false` if no executable is available.
Instead, the packages that use Singular know how they want to set the path of the Singular executable.
In the case of LiePRing, `StartSingular()` is called without changing the default path of the executable, thus we can provide a `TestAvailability` function for LiePRing that checks for an executable in the default locations.

This way, LiePRing is regarded as not loadable if no Singular executable is found; up to now, loading LiePRing ran into an error in this case.