### PR TITLE
make LiePRing independent of Singular

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -58,8 +58,8 @@ AvailabilityTest := ReturnTrue,
 
 Dependencies := rec(
   GAP := "4.8",
-  NeededOtherPackages := [["LieRing", ">=2.1"], ["Singular", ">=10"]],
-  SuggestedOtherPackages := [],
+  NeededOtherPackages := [["LieRing", ">=2.1"]],
+  SuggestedOtherPackages := [["Singular", ">=10"]],
   ExternalConditions := []
 ),
 

--- a/gap/singular.gi
+++ b/gap/singular.gi
@@ -1,0 +1,123 @@
+#############################################################################
+##
+## variables and polynomials are a problem - GAP is very slow in computing
+## with polynomials and Singular is fast, but has bugs.
+##
+
+IsSingularAvailable_known:= false;
+
+if not IsBound( StartSingular ) then
+  # Avoid warnings about unbound global variables.
+  StartSingular:= "dummy";
+fi;
+
+BindGlobal( "StartSingularIfAvailable", function()
+  local IsExec, sing_exec;
+
+  # Once we got a positive answer, we need not check.
+  if IsSingularAvailable_known = true then
+    return true;
+  fi;
+
+  # If the Singular package is not available
+  # then we cannot use the Singular executable.
+  if not IsPackageMarkedForLoading( "Singular", "" ) then
+    return false;
+  fi;
+
+  # Use the code from Singular's
+  # 'CheckSingularExecutableAndTempDir' in order to determine
+  # whether a Singular executable will be found by the Singular package.
+  # Note that the fact that the Singular package had been loaded
+  # does not imply that a Singular executable will be found.
+  IsExec:= path -> IsString( path ) and not IsDirectoryPath( path )
+                   and IsExecutableFile( path );
+
+  if IsBoundGlobal( "sing_exec" ) then
+    # The Singular package has been loaded.
+    sing_exec:= ValueGlobal( "sing_exec" );
+    if not IsString( sing_exec ) then
+      # This may happen after a failed 'StartSingular()' call.
+      sing_exec:= "singular";
+    fi;
+  else
+    # Use the default path.
+    sing_exec:= "singular";
+  fi;
+  if IsDirectoryPath( sing_exec ) then
+    sing_exec:= Filename( Directory( sing_exec ), "Singular" );
+  elif not IsExecutableFile( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), sing_exec );
+  fi;
+  if not IsExec( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), "Singular" );
+  fi;
+  if IsExec( sing_exec ) then
+    IsSingularAvailable_known:= true;
+    StartSingular();
+    return true;
+  fi;
+  return false;
+end );
+
+if IsString( StartSingular ) then
+  Unbind( StartSingular );
+fi;
+
+StartSingularIfAvailable();
+ORDER := MonomialGrlexOrdering();
+
+if not IsBound( SINGULARGBASIS ) then
+  SINGULARGBASIS:= "dummy";
+fi;
+
+BindGlobal( "CallGroebner", function( list )
+    local oldvar, new;
+    if Length(list) = 0 then return list; fi;
+    if StartSingularIfAvailable() then
+      # Use the Singular standalone.
+      oldvar := GBASIS;
+      GBASIS := SINGULARGBASIS;
+      new := GroebnerBasis(list, ORDER);
+      GBASIS := oldvar;
+    else
+      # Use GAP's implementation.
+      new := GroebnerBasis(list, ORDER);
+    fi;
+    return ReducedGroebnerBasis(new, ORDER);
+end );
+
+if IsString( SINGULARGBASIS ) then
+  Unbind( SINGULARGBASIS );
+fi;
+
+USE_GAP_FACS := false;
+
+if not IsBound( SingularSetBaseRing ) then
+  # Avoid warnings about unbound global variables.
+  SingularSetBaseRing:= "dummy";
+  FactorsUsingSingularNC:= "dummy";
+fi;
+
+BindGlobal( "MyFactors", function(pp, h)
+    local R, k, w, q;
+
+    if USE_GAP_FACS then return Factors(h); fi;
+    if not StartSingularIfAvailable() then return Factors(h); fi;
+
+    # singular is faster, but it has bugs ...
+    w := IndeterminateByName("w");
+    q := Concatenation(pp, [w]);
+    R := PolynomialRing(Rationals, q);
+    SingularSetBaseRing(R);
+    k := FactorsUsingSingularNC(h);
+    if Product(k) = h then return k{[2..Length(k)]}; fi;
+
+    # fall back
+    return Factors(h);
+end );
+
+if IsString( SingularSetBaseRing ) then
+  Unbind( SingularSetBaseRing );
+  Unbind( FactorsUsingSingularNC );
+fi;

--- a/read.g
+++ b/read.g
@@ -8,17 +8,92 @@
 ## with polynomials and Singular is fast, but has bugs.
 ##
 
-StartSingular();
+IsSingularAvailable_known:= false;
+
+if not IsBound( StartSingular ) then
+  # Avoid warnings about unbound global variables.
+  StartSingular:= "dummy";
+fi;
+
+BindGlobal( "StartSingularIfAvailable", function()
+  local IsExec, sing_exec;
+
+  # Once we got a positive answer, we need not check.
+  if IsSingularAvailable_known = true then
+    return true;
+  fi;
+
+  # If the Singular package is not available
+  # then we cannot use the Singular executable.
+  if not IsPackageMarkedForLoading( "Singular", "" ) then
+    return false;
+  fi;
+
+  # Use the code from Singular's
+  # 'CheckSingularExecutableAndTempDir' in order to determine
+  # whether a Singular executable will be found by the Singular package.
+  # Note that the fact that the Singular package had been loaded
+  # does not imply that a Singular executable will be found.
+  IsExec:= path -> IsString( path ) and not IsDirectoryPath( path )
+                   and IsExecutableFile( path );
+
+  if IsBoundGlobal( "sing_exec" ) then
+    # The Singular package has been loaded.
+    sing_exec:= ValueGlobal( "sing_exec" );
+    if not IsString( sing_exec ) then
+      # This may happen after a failed 'StartSingular()' call.
+      sing_exec:= "singular";
+    fi;
+  else
+    # Use the default path.
+    sing_exec:= "singular";
+  fi;
+  if IsDirectoryPath( sing_exec ) then
+    sing_exec:= Filename( Directory( sing_exec ), "Singular" );
+  elif not IsExecutableFile( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), sing_exec );
+  fi;
+  if not IsExec( sing_exec ) then
+    sing_exec:= Filename( DirectoriesSystemPrograms(), "Singular" );
+  fi;
+  if IsExec( sing_exec ) then
+    IsSingularAvailable_known:= true;
+    StartSingular();
+    return true;
+  fi;
+  return false;
+end );
+
+if IsString( StartSingular ) then
+  Unbind( StartSingular );
+fi;
+
+StartSingularIfAvailable();
 ORDER := MonomialGrlexOrdering();
 
+if not IsBound( SINGULARGBASIS ) then
+  SINGULARGBASIS:= "dummy";
+fi;
+
 BindGlobal( "CallGroebner", function( list )
-    local new;
+    local oldvar, new;
     if Length(list) = 0 then return list; fi;
-    GBASIS := SINGULARGBASIS;
-    new := GroebnerBasis(list, ORDER);
-    GBASIS := GAPGBASIS;
+    if StartSingularIfAvailable() then
+      # Use the Singular standalone.
+      oldvar := GBASIS;
+      GBASIS := SINGULARGBASIS;
+      new := GroebnerBasis(list, ORDER);
+      GBASIS := oldvar;
+    else
+      # Use GAP's implementation.
+      new := GroebnerBasis(list, ORDER);
+    fi;
     return ReducedGroebnerBasis(new, ORDER);
 end );
+
+if IsString( SINGULARGBASIS ) then
+  Unbind( SINGULARGBASIS );
+fi;
 
 OFFSET_VARS := 1000;
 BindGlobal( "IndeterminateByName", function( name )
@@ -35,10 +110,18 @@ BindGlobal( "IndeterminateByName", function( name )
 end );
 
 USE_GAP_FACS := false;
+
+if not IsBound( SingularSetBaseRing ) then
+  # Avoid warnings about unbound global variables.
+  SingularSetBaseRing:= "dummy";
+  FactorsUsingSingularNC:= "dummy";
+fi;
+
 BindGlobal( "MyFactors", function(pp, h)
     local R, k, w, q;
 
     if USE_GAP_FACS then return Factors(h); fi;
+    if not StartSingularIfAvailable() then return Factors(h); fi;
 
     # singular is faster, but it has bugs ...
     w := IndeterminateByName("w");
@@ -51,6 +134,11 @@ BindGlobal( "MyFactors", function(pp, h)
     # fall back
     return Factors(h);
 end );
+
+if IsString( SingularSetBaseRing ) then
+  Unbind( SingularSetBaseRing );
+  Unbind( FactorsUsingSingularNC );
+fi;
 
 BindGlobal( "LiePRing_ReadPackage", function(relpath)
     local preamble, code, c, filename, func;

--- a/read.g
+++ b/read.g
@@ -3,142 +3,23 @@
 ##
 ##
 
-##
-## variables and polynomials are a problem - GAP is very slow in computing
-## with polynomials and Singular is fast, but has bugs.
-##
-
-IsSingularAvailable_known:= false;
-
-if not IsBound( StartSingular ) then
-  # Avoid warnings about unbound global variables.
-  StartSingular:= "dummy";
-fi;
-
-BindGlobal( "StartSingularIfAvailable", function()
-  local IsExec, sing_exec;
-
-  # Once we got a positive answer, we need not check.
-  if IsSingularAvailable_known = true then
-    return true;
-  fi;
-
-  # If the Singular package is not available
-  # then we cannot use the Singular executable.
-  if not IsPackageMarkedForLoading( "Singular", "" ) then
-    return false;
-  fi;
-
-  # Use the code from Singular's
-  # 'CheckSingularExecutableAndTempDir' in order to determine
-  # whether a Singular executable will be found by the Singular package.
-  # Note that the fact that the Singular package had been loaded
-  # does not imply that a Singular executable will be found.
-  IsExec:= path -> IsString( path ) and not IsDirectoryPath( path )
-                   and IsExecutableFile( path );
-
-  if IsBoundGlobal( "sing_exec" ) then
-    # The Singular package has been loaded.
-    sing_exec:= ValueGlobal( "sing_exec" );
-    if not IsString( sing_exec ) then
-      # This may happen after a failed 'StartSingular()' call.
-      sing_exec:= "singular";
-    fi;
-  else
-    # Use the default path.
-    sing_exec:= "singular";
-  fi;
-  if IsDirectoryPath( sing_exec ) then
-    sing_exec:= Filename( Directory( sing_exec ), "Singular" );
-  elif not IsExecutableFile( sing_exec ) then
-    sing_exec:= Filename( DirectoriesSystemPrograms(), sing_exec );
-  fi;
-  if not IsExec( sing_exec ) then
-    sing_exec:= Filename( DirectoriesSystemPrograms(), "Singular" );
-  fi;
-  if IsExec( sing_exec ) then
-    IsSingularAvailable_known:= true;
-    StartSingular();
-    return true;
-  fi;
-  return false;
-end );
-
-if IsString( StartSingular ) then
-  Unbind( StartSingular );
-fi;
-
-StartSingularIfAvailable();
-ORDER := MonomialGrlexOrdering();
-
-if not IsBound( SINGULARGBASIS ) then
-  SINGULARGBASIS:= "dummy";
-fi;
-
-BindGlobal( "CallGroebner", function( list )
-    local oldvar, new;
-    if Length(list) = 0 then return list; fi;
-    if StartSingularIfAvailable() then
-      # Use the Singular standalone.
-      oldvar := GBASIS;
-      GBASIS := SINGULARGBASIS;
-      new := GroebnerBasis(list, ORDER);
-      GBASIS := oldvar;
-    else
-      # Use GAP's implementation.
-      new := GroebnerBasis(list, ORDER);
-    fi;
-    return ReducedGroebnerBasis(new, ORDER);
-end );
-
-if IsString( SINGULARGBASIS ) then
-  Unbind( SINGULARGBASIS );
-fi;
-
 OFFSET_VARS := 1000;
 BindGlobal( "IndeterminateByName", function( name )
     local l, i, v;
-    l := ["p", "w", 
-          "x", "y", "z", "t", "j", "k", "m", "n", "r", "s", "u", "v", 
-          "(p-1,3)", "(p-1,4)", "(p-1,5)", "(p-1,7)", "(p-1,8)", "(p-1,9)", 
+    l := ["p", "w",
+          "x", "y", "z", "t", "j", "k", "m", "n", "r", "s", "u", "v",
+          "(p-1,3)", "(p-1,4)", "(p-1,5)", "(p-1,7)", "(p-1,8)", "(p-1,9)",
           "(p+1,3)", "(p^2-1,16)", "a"];
     i := Position( l, name );
     if i = fail then return fail; fi;
-    v := Indeterminate(Integers, OFFSET_VARS+i); 
+    v := Indeterminate(Integers, OFFSET_VARS+i);
     if not HasName(v) then SetName(v,name); fi;
     return v;
 end );
 
-USE_GAP_FACS := false;
 
-if not IsBound( SingularSetBaseRing ) then
-  # Avoid warnings about unbound global variables.
-  SingularSetBaseRing:= "dummy";
-  FactorsUsingSingularNC:= "dummy";
-fi;
+ReadPackage( "liepring", "gap/singular.gi");
 
-BindGlobal( "MyFactors", function(pp, h)
-    local R, k, w, q;
-
-    if USE_GAP_FACS then return Factors(h); fi;
-    if not StartSingularIfAvailable() then return Factors(h); fi;
-
-    # singular is faster, but it has bugs ...
-    w := IndeterminateByName("w");
-    q := Concatenation(pp, [w]);
-    R := PolynomialRing(Rationals, q);
-    SingularSetBaseRing(R);
-    k := FactorsUsingSingularNC(h);
-    if Product(k) = h then return k{[2..Length(k)]}; fi;
-
-    # fall back
-    return Factors(h);
-end );
-
-if IsString( SingularSetBaseRing ) then
-  Unbind( SingularSetBaseRing );
-  Unbind( FactorsUsingSingularNC );
-fi;
 
 BindGlobal( "LiePRing_ReadPackage", function(relpath)
     local preamble, code, c, filename, func;


### PR DESCRIPTION
This is an alternative to #27.
Fix the bug that one runs into an error if one tries to load the package without a Singular executable being available.
Additionally, provide alternatives for the package functionality if no Singular executable is available:

- The Singular package is now not needed but suggested, and
- without the Singular package, GAP's factorization and Groebner bases are used.
- (And reset the variable `GBASIS` correctly if Singular is available; this is an independent fix.)

TODO:
If there is no Singular executable then one of the tests fails because the output is a little bit different.
This will be visible as soon as the CI tests get extended to the situation that no Singular executable is available. (Currently Singular gets installed in the CI tests, we could run the tests also in `only-needed` mode, once it is clear how to deal with the different output.)